### PR TITLE
remove attentionDuration from required collection

### DIFF
--- a/schemas/page-nav-sensitive.1.schema.json
+++ b/schemas/page-nav-sensitive.1.schema.json
@@ -48,7 +48,6 @@
     "type",
     "userId",
     "domain",
-    "attentionDuration",
     "visitDuration",
     "visitStartDate",
     "visitStartHour"


### PR DESCRIPTION
Because we cannot guarantee timing of updates for clients, attentionDuration cannot be set as required.